### PR TITLE
ci: jscpd duplication gate

### DIFF
--- a/.github/scripts/__tests__/ci-workflow.test.mjs
+++ b/.github/scripts/__tests__/ci-workflow.test.mjs
@@ -11,3 +11,10 @@ test("PR CI workflow reruns on edited pull requests", async () => {
     /pull_request:\n(?: {4}types:\n| {6}- .*\n)* {6}- edited\b/m,
   );
 });
+
+test("PR CI workflow checks duplicated code with jscpd", async () => {
+  const workflowPath = new URL("../../workflows/ci.yml", import.meta.url);
+  const workflowContents = await readFile(workflowPath, "utf8");
+
+  assert.match(workflowContents, /run: npm run jscpd/);
+});

--- a/.github/scripts/github-client.mjs
+++ b/.github/scripts/github-client.mjs
@@ -1,0 +1,54 @@
+export function createGitHubClient(token, userAgent) {
+  return async function github(path, init = {}) {
+    const response = await fetch(`https://api.github.com${path}`, {
+      ...init,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": userAgent,
+        ...init.headers,
+      },
+    });
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const message = data?.message ?? response.statusText;
+      const error = new Error(`${response.status} ${message}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+export async function upsertLabel(github, owner, repo, label) {
+  const encodedName = encodeURIComponent(label.name);
+
+  try {
+    await github(`/repos/${owner}/${repo}/labels/${encodedName}`);
+    await github(`/repos/${owner}/${repo}/labels/${encodedName}`, {
+      method: "PATCH",
+      body: JSON.stringify(label),
+    });
+    return "updated";
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+  }
+
+  await github(`/repos/${owner}/${repo}/labels`, {
+    method: "POST",
+    body: JSON.stringify(label),
+  });
+  return "created";
+}

--- a/.github/scripts/pr-dependencies.mjs
+++ b/.github/scripts/pr-dependencies.mjs
@@ -3,50 +3,21 @@
 import { readFile } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGitHubClient, upsertLabel } from "./github-client.mjs";
 
 export const DEPENDENTS_LABEL = "has-dependents";
 export const DEPENDS_ON_PATTERN = /^depends-on:#(\d+)$/;
 export const STACK_BRANCH_PATTERN = /^feat\//;
 const DYNAMIC_DEPENDENCY_LABEL_COLOR = "bfd4f2";
 
-function createGitHubClient(token) {
-  return async function github(path, init = {}) {
-    const response = await fetch(`https://api.github.com${path}`, {
-      ...init,
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        "User-Agent": "towncord-pr-dependencies",
-        ...init.headers,
-      },
-    });
-
-    if (response.status === 204) {
-      return null;
-    }
-
-    const text = await response.text();
-    const data = text ? JSON.parse(text) : null;
-
-    if (!response.ok) {
-      const message = data?.message ?? response.statusText;
-      const error = new Error(`${response.status} ${message}`);
-      error.status = response.status;
-      error.data = data;
-      throw error;
-    }
-
-    return data;
-  };
-}
-
 async function paginate(github, path) {
   const items = [];
   let page = 1;
 
   while (true) {
-    const data = await github(`${path}${path.includes("?") ? "&" : "?"}per_page=100&page=${page}`);
+    const data = await github(
+      `${path}${path.includes("?") ? "&" : "?"}per_page=100&page=${page}`,
+    );
     items.push(...data);
 
     if (data.length < 100) {
@@ -62,34 +33,19 @@ async function ensureLabels(github, owner, repo) {
   const labels = JSON.parse(await readFile(labelsPath, "utf8"));
 
   for (const label of labels) {
-    const encodedName = encodeURIComponent(label.name);
-    let exists = false;
-
-    try {
-      await github(`/repos/${owner}/${repo}/labels/${encodedName}`);
-      exists = true;
-    } catch (error) {
-      if (error.status !== 404) {
-        throw error;
-      }
-    }
-
-    if (exists) {
-      await github(`/repos/${owner}/${repo}/labels/${encodedName}`, {
-        method: "PATCH",
-        body: JSON.stringify(label),
-      });
-      continue;
-    }
-
-    await github(`/repos/${owner}/${repo}/labels`, {
-      method: "POST",
-      body: JSON.stringify(label),
-    });
+    await upsertLabel(github, owner, repo, label);
   }
 }
 
-async function toggleLabel(github, owner, repo, prNumber, labelsByName, labelName, shouldExist) {
+async function toggleLabel(
+  github,
+  owner,
+  repo,
+  prNumber,
+  labelsByName,
+  labelName,
+  shouldExist,
+) {
   const hasLabel = labelsByName.has(labelName);
 
   if (shouldExist && !hasLabel) {
@@ -101,31 +57,20 @@ async function toggleLabel(github, owner, repo, prNumber, labelsByName, labelNam
   }
 
   if (!shouldExist && hasLabel) {
-    await github(`/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent(labelName)}`, {
-      method: "DELETE",
-    });
+    await github(
+      `/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent(labelName)}`,
+      {
+        method: "DELETE",
+      },
+    );
   }
 }
 
 async function ensureDynamicDependencyLabel(github, owner, repo, labelName) {
-  const encodedName = encodeURIComponent(labelName);
-
-  try {
-    await github(`/repos/${owner}/${repo}/labels/${encodedName}`);
-    return;
-  } catch (error) {
-    if (error.status !== 404) {
-      throw error;
-    }
-  }
-
-  await github(`/repos/${owner}/${repo}/labels`, {
-    method: "POST",
-    body: JSON.stringify({
-      name: labelName,
-      color: DYNAMIC_DEPENDENCY_LABEL_COLOR,
-      description: "Automatically managed stacked PR dependency label.",
-    }),
+  await upsertLabel(github, owner, repo, {
+    name: labelName,
+    color: DYNAMIC_DEPENDENCY_LABEL_COLOR,
+    description: "Automatically managed stacked PR dependency label.",
   });
 }
 
@@ -177,7 +122,9 @@ export function computeDependencyUpdates(openPulls) {
 
   for (const pr of openPulls) {
     const parentPr = resolveParentPull(pr, parentPullsByHeadRef);
-    const dependencyLabelName = parentPr ? `depends-on:#${parentPr.number}` : null;
+    const dependencyLabelName = parentPr
+      ? `depends-on:#${parentPr.number}`
+      : null;
 
     if (dependencyLabelName) {
       desiredDependencyLabelByPrNumber.set(pr.number, dependencyLabelName);
@@ -190,7 +137,8 @@ export function computeDependencyUpdates(openPulls) {
 
   return openPulls.map((pr) => ({
     prNumber: pr.number,
-    desiredDependencyLabel: desiredDependencyLabelByPrNumber.get(pr.number) ?? null,
+    desiredDependencyLabel:
+      desiredDependencyLabelByPrNumber.get(pr.number) ?? null,
     hasDependents: (childCountByParentPrNumber.get(pr.number) ?? 0) > 0,
   }));
 }
@@ -208,38 +156,74 @@ export async function main({
   }
 
   const [owner, repo] = repository.split("/");
-  const github = createGitHubClient(token);
+  const github = createGitHubClient(token, "towncord-pr-dependencies");
 
   await ensureLabels(github, owner, repo);
 
-  const openPulls = await paginate(github, `/repos/${owner}/${repo}/pulls?state=open`);
+  const openPulls = await paginate(
+    github,
+    `/repos/${owner}/${repo}/pulls?state=open`,
+  );
   const dependencyUpdatesByPrNumber = new Map(
-    computeDependencyUpdates(openPulls).map((update) => [update.prNumber, update]),
+    computeDependencyUpdates(openPulls).map((update) => [
+      update.prNumber,
+      update,
+    ]),
   );
 
   for (const pr of openPulls) {
     const labelsByName = new Set((pr.labels ?? []).map((label) => label.name));
     const existingDependencyLabels = getDependencyLabelNames(pr);
     const dependencyUpdate = dependencyUpdatesByPrNumber.get(pr.number);
-    const desiredDependencyLabel = dependencyUpdate?.desiredDependencyLabel ?? null;
+    const desiredDependencyLabel =
+      dependencyUpdate?.desiredDependencyLabel ?? null;
 
     for (const labelName of existingDependencyLabels) {
       if (labelName === desiredDependencyLabel) {
         continue;
       }
 
-      await toggleLabel(github, owner, repo, pr.number, labelsByName, labelName, false);
+      await toggleLabel(
+        github,
+        owner,
+        repo,
+        pr.number,
+        labelsByName,
+        labelName,
+        false,
+      );
       labelsByName.delete(labelName);
     }
 
     if (desiredDependencyLabel) {
-      await ensureDynamicDependencyLabel(github, owner, repo, desiredDependencyLabel);
-      await toggleLabel(github, owner, repo, pr.number, labelsByName, desiredDependencyLabel, true);
+      await ensureDynamicDependencyLabel(
+        github,
+        owner,
+        repo,
+        desiredDependencyLabel,
+      );
+      await toggleLabel(
+        github,
+        owner,
+        repo,
+        pr.number,
+        labelsByName,
+        desiredDependencyLabel,
+        true,
+      );
       labelsByName.add(desiredDependencyLabel);
     }
 
     const hasDependents = dependencyUpdate?.hasDependents ?? false;
-    await toggleLabel(github, owner, repo, pr.number, labelsByName, DEPENDENTS_LABEL, hasDependents);
+    await toggleLabel(
+      github,
+      owner,
+      repo,
+      pr.number,
+      labelsByName,
+      DEPENDENTS_LABEL,
+      hasDependents,
+    );
 
     console.log(
       `Processed PR #${pr.number}: dependency=${desiredDependencyLabel ?? "none"}, hasDependents=${hasDependents}`,
@@ -248,7 +232,8 @@ export async function main({
 }
 
 const isDirectExecution =
-  process.argv[1] && resolvePath(process.argv[1]) === fileURLToPath(import.meta.url);
+  process.argv[1] &&
+  resolvePath(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (isDirectExecution) {
   await main();

--- a/.github/scripts/sync-labels.mjs
+++ b/.github/scripts/sync-labels.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFile } from "node:fs/promises";
+import { createGitHubClient, upsertLabel } from "./github-client.mjs";
 
 const token = process.env.GITHUB_TOKEN;
 const repository = process.env.GITHUB_REPOSITORY;
@@ -16,66 +17,11 @@ if (!repository) {
 const [owner, repo] = repository.split("/");
 const labelsPath = new URL("../labels.json", import.meta.url);
 const labels = JSON.parse(await readFile(labelsPath, "utf8"));
-
-async function github(path, init = {}) {
-  const response = await fetch(`https://api.github.com${path}`, {
-    ...init,
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "User-Agent": "towncord-label-sync",
-      ...init.headers,
-    },
-  });
-
-  if (response.status === 204) {
-    return null;
-  }
-
-  const text = await response.text();
-  const data = text ? JSON.parse(text) : null;
-
-  if (!response.ok) {
-    const message = data?.message ?? response.statusText;
-    const error = new Error(`${response.status} ${message}`);
-    error.status = response.status;
-    error.data = data;
-    throw error;
-  }
-
-  return data;
-}
-
-async function upsertLabel(label) {
-  const encodedName = encodeURIComponent(label.name);
-  let exists = false;
-
-  try {
-    await github(`/repos/${owner}/${repo}/labels/${encodedName}`);
-    exists = true;
-  } catch (error) {
-    if (error.status !== 404) {
-      throw error;
-    }
-  }
-
-  if (exists) {
-    await github(`/repos/${owner}/${repo}/labels/${encodedName}`, {
-      method: "PATCH",
-      body: JSON.stringify(label),
-    });
-    console.log(`Updated label: ${label.name}`);
-    return;
-  }
-
-  await github(`/repos/${owner}/${repo}/labels`, {
-    method: "POST",
-    body: JSON.stringify(label),
-  });
-  console.log(`Created label: ${label.name}`);
-}
+const github = createGitHubClient(token, "towncord-label-sync");
 
 for (const label of labels) {
-  await upsertLabel(label);
+  const result = await upsertLabel(github, owner, repo, label);
+  console.log(
+    `${result === "created" ? "Created" : "Updated"} label: ${label.name}`,
+  );
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Find unused dependencies, exports, and files
         run: npm run knip
 
+      - name: Find duplicated code
+        run: npm run jscpd
+
       - name: Typecheck frontend
         run: npm run typecheck:frontend
 

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,10 @@
+{
+  "threshold": 0,
+  "gitignore": true,
+  "reporters": ["console"],
+  "path": [
+    ".github/scripts",
+    "apps/frontend",
+    "packages/public-animation-contracts"
+  ]
+}

--- a/apps/frontend/src/components/sidebar/AnimationInfoPanel.tsx
+++ b/apps/frontend/src/components/sidebar/AnimationInfoPanel.tsx
@@ -1,19 +1,20 @@
 import { useState } from "react";
 import type { PreviewInfo } from "../AnimationPreview";
-import { AccordionHeader, SectionLabel } from "./common";
+import {
+  AccordionHeader,
+  KeyValueRow,
+  PanelBody,
+  SectionLabel,
+} from "./common";
 
 type Props = {
   animInfo: PreviewInfo | null;
 };
 
-function InfoRow({ label, value }: { label: string; value: string }): JSX.Element {
-  return (
-    <div style={{ display: "flex", justifyContent: "space-between", gap: 4 }}>
-      <span style={{ color: "#64748b" }}>{label}</span>
-      <span style={{ color: "#cbd5e1", textAlign: "right", wordBreak: "break-all" }}>{value}</span>
-    </div>
-  );
-}
+const INFO_VALUE_STYLE: React.CSSProperties = {
+  textAlign: "right",
+  wordBreak: "break-all",
+};
 
 export function AnimationInfoPanel({ animInfo }: Props): JSX.Element {
   const [animOpen, setAnimOpen] = useState(true);
@@ -21,56 +22,107 @@ export function AnimationInfoPanel({ animInfo }: Props): JSX.Element {
   return (
     <>
       <SectionLabel>Info</SectionLabel>
-      <AccordionHeader label="Animation" open={animOpen} onToggle={() => setAnimOpen((v) => !v)} />
+      <AccordionHeader
+        label="Animation"
+        open={animOpen}
+        onToggle={() => setAnimOpen((v) => !v)}
+      />
       {animOpen && (
-        <div
-          style={{
-            background: "rgba(15, 23, 42, 0.5)",
-            border: "1px solid rgba(255,255,255,0.08)",
-            borderRadius: 4,
-            display: "flex",
-            flexDirection: "column",
-            fontSize: 11,
-            gap: 3,
-            marginLeft: 4,
-            padding: "6px 7px",
-          }}
-        >
+        <PanelBody gap={3}>
           {animInfo ? (
             <>
-              <InfoRow
+              <KeyValueRow
                 label="type"
-                value={animInfo.sourceType === "terrain-tile" ? "terrain tile" : "animation"}
+                value={
+                  animInfo.sourceType === "terrain-tile"
+                    ? "terrain tile"
+                    : "animation"
+                }
+                gap={4}
+                valueStyle={INFO_VALUE_STYLE}
               />
-              <InfoRow label="key" value={animInfo.animationKey} />
+              <KeyValueRow
+                label="key"
+                value={animInfo.animationKey}
+                gap={4}
+                valueStyle={INFO_VALUE_STYLE}
+              />
               {animInfo.sourceType === "terrain-tile" && (
                 <>
-                  <InfoRow label="material" value={animInfo.materialId ?? "-"} />
-                  <InfoRow
+                  <KeyValueRow
+                    label="material"
+                    value={animInfo.materialId ?? "-"}
+                    gap={4}
+                    valueStyle={INFO_VALUE_STYLE}
+                  />
+                  <KeyValueRow
                     label="cell"
                     value={
-                      animInfo.cellX !== undefined && animInfo.cellY !== undefined
+                      animInfo.cellX !== undefined &&
+                      animInfo.cellY !== undefined
                         ? `${animInfo.cellX},${animInfo.cellY}`
                         : "-"
                     }
+                    gap={4}
+                    valueStyle={INFO_VALUE_STYLE}
                   />
-                  <InfoRow label="case" value={animInfo.caseId !== undefined ? String(animInfo.caseId) : "-"} />
-                  <InfoRow
+                  <KeyValueRow
+                    label="case"
+                    value={
+                      animInfo.caseId !== undefined
+                        ? String(animInfo.caseId)
+                        : "-"
+                    }
+                    gap={4}
+                    valueStyle={INFO_VALUE_STYLE}
+                  />
+                  <KeyValueRow
                     label="rotate90"
-                    value={animInfo.rotate90 !== undefined ? String(animInfo.rotate90) : "0"}
+                    value={
+                      animInfo.rotate90 !== undefined
+                        ? String(animInfo.rotate90)
+                        : "0"
+                    }
+                    gap={4}
+                    valueStyle={INFO_VALUE_STYLE}
                   />
-                  <InfoRow label="flipY" value={animInfo.flipY ? "yes" : "no"} />
+                  <KeyValueRow
+                    label="flipY"
+                    value={animInfo.flipY ? "yes" : "no"}
+                    gap={4}
+                    valueStyle={INFO_VALUE_STYLE}
+                  />
                 </>
               )}
-              <InfoRow label="frame" value={`${animInfo.frameWidth}×${animInfo.frameHeight}`} />
-              <InfoRow label="frames" value={String(animInfo.frameCount)} />
-              <InfoRow label="display" value={`${animInfo.displayWidth}×${animInfo.displayHeight}`} />
-              <InfoRow label="flipX" value={animInfo.flipX ? "yes" : "no"} />
+              <KeyValueRow
+                label="frame"
+                value={`${animInfo.frameWidth}×${animInfo.frameHeight}`}
+                gap={4}
+                valueStyle={INFO_VALUE_STYLE}
+              />
+              <KeyValueRow
+                label="frames"
+                value={String(animInfo.frameCount)}
+                gap={4}
+                valueStyle={INFO_VALUE_STYLE}
+              />
+              <KeyValueRow
+                label="display"
+                value={`${animInfo.displayWidth}×${animInfo.displayHeight}`}
+                gap={4}
+                valueStyle={INFO_VALUE_STYLE}
+              />
+              <KeyValueRow
+                label="flipX"
+                value={animInfo.flipX ? "yes" : "no"}
+                gap={4}
+                valueStyle={INFO_VALUE_STYLE}
+              />
             </>
           ) : (
             <span style={{ color: "#475569" }}>Loading preview…</span>
           )}
-        </div>
+        </PanelBody>
       )}
     </>
   );

--- a/apps/frontend/src/components/sidebar/RuntimePerfPanel.tsx
+++ b/apps/frontend/src/components/sidebar/RuntimePerfPanel.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import type { RuntimePerfPayload } from "../../game/events";
-import { AccordionHeader, SectionLabel } from "./common";
+import {
+  AccordionHeader,
+  KeyValueRow,
+  PanelBody,
+  SectionLabel,
+} from "./common";
 
 type Props = {
   perf: RuntimePerfPayload | null;
@@ -28,17 +33,51 @@ function toLinePoints(values: number[], maxValue: number): string {
   return values
     .map((value, index) => {
       const x = (index / span) * CHART_WIDTH;
-      const y = CHART_HEIGHT - (Math.max(0, Math.min(value, maxValue)) / maxValue) * CHART_HEIGHT;
+      const y =
+        CHART_HEIGHT -
+        (Math.max(0, Math.min(value, maxValue)) / maxValue) * CHART_HEIGHT;
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
 }
 
-function StatRow({ label, value }: { label: string; value: string }): JSX.Element {
+const CHART_SECTION_STYLE: React.CSSProperties = {
+  borderTop: "1px solid rgba(255,255,255,0.08)",
+  marginTop: 2,
+  paddingTop: 6,
+};
+
+const CHART_STYLE: React.CSSProperties = {
+  background: "rgba(2, 6, 23, 0.6)",
+  border: "1px solid rgba(148,163,184,0.2)",
+  borderRadius: 4,
+};
+
+function HistoryChart({
+  title,
+  points,
+  stroke,
+  summary,
+}: {
+  title: string;
+  points: string;
+  stroke: string;
+  summary: string;
+}): JSX.Element {
   return (
-    <div style={{ display: "flex", justifyContent: "space-between", gap: 6 }}>
-      <span style={{ color: "#64748b" }}>{label}</span>
-      <span style={{ color: "#cbd5e1" }}>{value}</span>
+    <div style={CHART_SECTION_STYLE}>
+      <div style={{ color: "#94a3b8", marginBottom: 4 }}>{title}</div>
+      <svg
+        width={CHART_WIDTH}
+        height={CHART_HEIGHT}
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        style={CHART_STYLE}
+      >
+        <polyline fill="none" stroke={stroke} strokeWidth="2" points={points} />
+      </svg>
+      <div style={{ color: "#64748b", fontSize: 10, marginTop: 2 }}>
+        {summary}
+      </div>
     </div>
   );
 }
@@ -64,7 +103,10 @@ export function RuntimePerfPanel({ perf }: Props): JSX.Element {
     return Math.max(16, Math.ceil(historyMax / 4) * 4);
   }, [updateHistory]);
 
-  const fpsPoints = useMemo(() => toLinePoints(fpsHistory, fpsMax), [fpsHistory, fpsMax]);
+  const fpsPoints = useMemo(
+    () => toLinePoints(fpsHistory, fpsMax),
+    [fpsHistory, fpsMax],
+  );
   const updatePoints = useMemo(
     () => toLinePoints(updateHistory, updateMax),
     [updateHistory, updateMax],
@@ -73,62 +115,41 @@ export function RuntimePerfPanel({ perf }: Props): JSX.Element {
   return (
     <>
       <SectionLabel>Diagnostics</SectionLabel>
-      <AccordionHeader label="Performance" open={open} onToggle={() => setOpen((v) => !v)} />
+      <AccordionHeader
+        label="Performance"
+        open={open}
+        onToggle={() => setOpen((v) => !v)}
+      />
       {open && (
-        <div
-          style={{
-            background: "rgba(15, 23, 42, 0.5)",
-            border: "1px solid rgba(255,255,255,0.08)",
-            borderRadius: 4,
-            display: "flex",
-            flexDirection: "column",
-            fontSize: 11,
-            gap: 6,
-            marginLeft: 4,
-            padding: "6px 7px",
-          }}
-        >
+        <PanelBody>
           {perf ? (
             <>
-              <StatRow label="fps" value={perf.fps.toFixed(1)} />
-              <StatRow label="frame ms" value={perf.frameMs.toFixed(2)} />
-              <StatRow label="update ms" value={perf.updateMs.toFixed(2)} />
-              <StatRow label="terrain ms" value={perf.terrainMs.toFixed(2)} />
-
-              <div style={{ borderTop: "1px solid rgba(255,255,255,0.08)", marginTop: 2, paddingTop: 6 }}>
-                <div style={{ color: "#94a3b8", marginBottom: 4 }}>FPS history</div>
-                <svg
-                  width={CHART_WIDTH}
-                  height={CHART_HEIGHT}
-                  viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
-                  style={{ background: "rgba(2, 6, 23, 0.6)", border: "1px solid rgba(148,163,184,0.2)", borderRadius: 4 }}
-                >
-                  <polyline fill="none" stroke="#22c55e" strokeWidth="2" points={fpsPoints} />
-                </svg>
-                <div style={{ color: "#64748b", fontSize: 10, marginTop: 2 }}>
-                  avg {average(fpsHistory).toFixed(1)} · max scale {fpsMax}
-                </div>
-              </div>
-
-              <div style={{ borderTop: "1px solid rgba(255,255,255,0.08)", marginTop: 2, paddingTop: 6 }}>
-                <div style={{ color: "#94a3b8", marginBottom: 4 }}>Runtime history (ms)</div>
-                <svg
-                  width={CHART_WIDTH}
-                  height={CHART_HEIGHT}
-                  viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
-                  style={{ background: "rgba(2, 6, 23, 0.6)", border: "1px solid rgba(148,163,184,0.2)", borderRadius: 4 }}
-                >
-                  <polyline fill="none" stroke="#f59e0b" strokeWidth="2" points={updatePoints} />
-                </svg>
-                <div style={{ color: "#64748b", fontSize: 10, marginTop: 2 }}>
-                  avg {average(updateHistory).toFixed(2)} · max scale {updateMax}ms
-                </div>
-              </div>
+              <KeyValueRow label="fps" value={perf.fps.toFixed(1)} />
+              <KeyValueRow label="frame ms" value={perf.frameMs.toFixed(2)} />
+              <KeyValueRow label="update ms" value={perf.updateMs.toFixed(2)} />
+              <KeyValueRow
+                label="terrain ms"
+                value={perf.terrainMs.toFixed(2)}
+              />
+              <HistoryChart
+                title="FPS history"
+                points={fpsPoints}
+                stroke="#22c55e"
+                summary={`avg ${average(fpsHistory).toFixed(1)} · max scale ${fpsMax}`}
+              />
+              <HistoryChart
+                title="Runtime history (ms)"
+                points={updatePoints}
+                stroke="#f59e0b"
+                summary={`avg ${average(updateHistory).toFixed(2)} · max scale ${updateMax}ms`}
+              />
             </>
           ) : (
-            <span style={{ color: "#475569" }}>Waiting for runtime perf samples…</span>
+            <span style={{ color: "#475569" }}>
+              Waiting for runtime perf samples…
+            </span>
           )}
-        </div>
+        </PanelBody>
       )}
     </>
   );

--- a/apps/frontend/src/components/sidebar/common.tsx
+++ b/apps/frontend/src/components/sidebar/common.tsx
@@ -29,8 +29,52 @@ const SECTION_LABEL_STYLE: React.CSSProperties = {
   textTransform: "uppercase",
 };
 
-export function SectionLabel({ children }: { children: React.ReactNode }): JSX.Element {
+const PANEL_BODY_STYLE: React.CSSProperties = {
+  background: "rgba(15, 23, 42, 0.5)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 4,
+  display: "flex",
+  flexDirection: "column",
+  fontSize: 11,
+  marginLeft: 4,
+  padding: "6px 7px",
+};
+
+export function SectionLabel({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
   return <div style={SECTION_LABEL_STYLE}>{children}</div>;
+}
+
+export function PanelBody({
+  children,
+  gap = 6,
+}: {
+  children: React.ReactNode;
+  gap?: number;
+}): JSX.Element {
+  return <div style={{ ...PANEL_BODY_STYLE, gap }}>{children}</div>;
+}
+
+export function KeyValueRow({
+  label,
+  value,
+  gap = 6,
+  valueStyle,
+}: {
+  label: string;
+  value: string;
+  gap?: number;
+  valueStyle?: React.CSSProperties;
+}): JSX.Element {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", gap }}>
+      <span style={{ color: "#64748b" }}>{label}</span>
+      <span style={{ color: "#cbd5e1", ...valueStyle }}>{value}</span>
+    </div>
+  );
 }
 
 export function AccordionHeader({
@@ -45,7 +89,11 @@ export function AccordionHeader({
   return (
     <button
       onClick={onToggle}
-      style={{ ...BUTTON_BASE, background: "rgba(255,255,255,0.05)", color: "#e2e8f0" }}
+      style={{
+        ...BUTTON_BASE,
+        background: "rgba(255,255,255,0.05)",
+        color: "#e2e8f0",
+      }}
     >
       {open ? "▾" : "▸"} {label}
     </button>

--- a/apps/frontend/src/game/assets/__tests__/animationTiming.test.ts
+++ b/apps/frontend/src/game/assets/__tests__/animationTiming.test.ts
@@ -9,7 +9,9 @@ function createScene(manifest: unknown) {
     scene: {
       cache: {
         json: {
-          get: vi.fn((key: string) => (key === BLOOMSEED_ANIMATIONS_JSON_KEY ? manifest : null)),
+          get: vi.fn((key: string) =>
+            key === BLOOMSEED_ANIMATIONS_JSON_KEY ? manifest : null,
+          ),
         },
       },
       textures: {
@@ -22,6 +24,36 @@ function createScene(manifest: unknown) {
     },
     create,
   };
+}
+
+function createTimingManifest(durationsMs: unknown) {
+  return {
+    namespace: "bloomseed",
+    animations: {
+      "characters.hero.walk": {
+        atlasKey: "bloomseed.characters",
+        frames: ["walk#0", "walk#1"],
+        durationsMs,
+        phaseDurationsMs: [80, 120],
+        category: "characters",
+        frameCount: 2,
+        frameSize: { w: 16, h: 16 },
+        sourceFile: "aseprite/characters/hero.aseprite",
+      },
+    },
+  };
+}
+
+function expectInvalidDurationsManifest(
+  durationsMs: unknown,
+  expectedMessage: RegExp | string,
+): void {
+  const { scene, create } = createScene(createTimingManifest(durationsMs));
+
+  expect(() => registerBloomseedAnimations(scene as never)).toThrow(
+    expectedMessage,
+  );
+  expect(create).not.toHaveBeenCalled();
 }
 
 describe("registerBloomseedAnimations timing", () => {
@@ -83,71 +115,23 @@ describe("registerBloomseedAnimations timing", () => {
   });
 
   test("throws when exported durations include non-integer values", () => {
-    const { scene, create } = createScene({
-      namespace: "bloomseed",
-      animations: {
-        "characters.hero.walk": {
-          atlasKey: "bloomseed.characters",
-          frames: ["walk#0", "walk#1"],
-          durationsMs: [80.5, 120],
-          phaseDurationsMs: [80, 120],
-          category: "characters",
-          frameCount: 2,
-          frameSize: { w: 16, h: 16 },
-          sourceFile: "aseprite/characters/hero.aseprite",
-        },
-      },
-    });
-
-    expect(() => registerBloomseedAnimations(scene as never)).toThrow(
+    expectInvalidDurationsManifest(
+      [80.5, 120],
       /Invalid animation manifest for cache key "bloomseed\.animations"\..*must be integer/,
     );
-    expect(create).not.toHaveBeenCalled();
   });
 
   test("throws when exported durations include non-positive values", () => {
-    const { scene, create } = createScene({
-      namespace: "bloomseed",
-      animations: {
-        "characters.hero.walk": {
-          atlasKey: "bloomseed.characters",
-          frames: ["walk#0", "walk#1"],
-          durationsMs: [0, 120],
-          phaseDurationsMs: [80, 120],
-          category: "characters",
-          frameCount: 2,
-          frameSize: { w: 16, h: 16 },
-          sourceFile: "aseprite/characters/hero.aseprite",
-        },
-      },
-    });
-
-    expect(() => registerBloomseedAnimations(scene as never)).toThrow(
+    expectInvalidDurationsManifest(
+      [0, 120],
       /Invalid animation manifest for cache key "bloomseed\.animations"\..*must be >= 1/,
     );
-    expect(create).not.toHaveBeenCalled();
   });
 
   test("throws when exported durations are not an array", () => {
-    const { scene, create } = createScene({
-      namespace: "bloomseed",
-      animations: {
-        "characters.hero.walk": {
-          atlasKey: "bloomseed.characters",
-          frames: ["walk#0", "walk#1"],
-          durationsMs: "not-an-array",
-          phaseDurationsMs: [80, 120],
-          category: "characters",
-          frameCount: 2,
-          frameSize: { w: 16, h: 16 },
-          sourceFile: "aseprite/characters/hero.aseprite",
-        },
-      },
-    });
-
-    expect(() => registerBloomseedAnimations(scene as never)).toThrow(
+    expectInvalidDurationsManifest(
+      "not-an-array",
       /Invalid animation manifest for cache key "bloomseed\.animations"\..*must be array/,
     );
-    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/game/assets/animationCatalog.ts
+++ b/apps/frontend/src/game/assets/animationCatalog.ts
@@ -44,10 +44,19 @@ function getSpriteDirection(segment: string): SpriteDirection | null {
 function getOrCreate(
   map: Map<string, AnimationTrack>,
   id: string,
-  defaults: Omit<AnimationTrack, "id" | "directional" | "keyByDirection" | "undirectedKey">,
+  defaults: Omit<
+    AnimationTrack,
+    "id" | "directional" | "keyByDirection" | "undirectedKey"
+  >,
 ): AnimationTrack {
   if (!map.has(id)) {
-    map.set(id, { id, ...defaults, directional: false, keyByDirection: {}, undirectedKey: null });
+    map.set(id, {
+      id,
+      ...defaults,
+      directional: false,
+      keyByDirection: {},
+      undirectedKey: null,
+    });
   }
   return map.get(id)!;
 }
@@ -104,7 +113,9 @@ function parseMobKeys(
       ? lastSegment.slice(mobPrefix.length)
       : lastSegment;
     const dir = getSpriteDirection(actionSegment);
-    const actionId = dir ? actionSegment.slice(0, actionSegment.length - `-${dir}`.length) : actionSegment;
+    const actionId = dir
+      ? actionSegment.slice(0, actionSegment.length - `-${dir}`.length)
+      : actionSegment;
 
     const path = `mobs/${family}/${mobId}`;
     if (!pathTracks.has(path)) pathTracks.set(path, new Map());
@@ -184,7 +195,10 @@ function parseTilesetKeys(
       family = "static";
       group = parts[2]!;
       tilesetType = parts[3]!;
-    } else if (parts.length === 5 && (parts[2] === "animated" || parts[2] === "static")) {
+    } else if (
+      parts.length === 5 &&
+      (parts[2] === "animated" || parts[2] === "static")
+    ) {
       family = parts[2];
       group = parts[3]!;
       tilesetType = parts[4]!;
@@ -204,7 +218,9 @@ function parseTilesetKeys(
   }
 }
 
-export function buildAnimationCatalog(animationKeys: string[]): AnimationCatalog {
+export function buildAnimationCatalog(
+  animationKeys: string[],
+): AnimationCatalog {
   const pathTracks = new Map<string, Map<string, AnimationTrack>>();
   parsePlayerKeys(animationKeys, pathTracks);
   parseMobKeys(animationKeys, pathTracks);
@@ -213,7 +229,10 @@ export function buildAnimationCatalog(animationKeys: string[]): AnimationCatalog
 
   const tracksByPath = new Map<string, AnimationTrack[]>();
   for (const [path, map] of pathTracks) {
-    tracksByPath.set(path, [...map.values()].sort((a, b) => a.id.localeCompare(b.id)));
+    tracksByPath.set(
+      path,
+      [...map.values()].sort((a, b) => a.id.localeCompare(b.id)),
+    );
   }
 
   const playerModels = new Set<string>();
@@ -262,7 +281,9 @@ export function resolveTrackForDirection(
     if (key) return { key, flipX };
     // Fallback order: down → up → side
     const fallbackKey =
-      track.keyByDirection["down"] ?? track.keyByDirection["up"] ?? track.keyByDirection["side"];
+      track.keyByDirection["down"] ??
+      track.keyByDirection["up"] ??
+      track.keyByDirection["side"];
     if (fallbackKey) return { key: fallbackKey, flipX: false };
   }
 
@@ -272,11 +293,7 @@ export function resolveTrackForDirection(
 
 /** Returns mob IDs available under a given family. */
 export function getMobIds(catalog: AnimationCatalog, family: string): string[] {
-  const prefix = `mobs/${family}/`;
-  return [...catalog.tracksByPath.keys()]
-    .filter((p) => p.startsWith(prefix))
-    .map((p) => p.slice(prefix.length))
-    .sort();
+  return listCatalogPathSuffixes(catalog, `mobs/${family}/`);
 }
 
 function parseMobVisualPath(path: string): MobCatalogDescriptor | null {
@@ -285,7 +302,19 @@ function parseMobVisualPath(path: string): MobCatalogDescriptor | null {
   return { family, mobId, visualPath: path };
 }
 
-export function listMobDescriptors(catalog: AnimationCatalog): MobCatalogDescriptor[] {
+function listCatalogPathSuffixes(
+  catalog: AnimationCatalog,
+  prefix: string,
+): string[] {
+  return [...catalog.tracksByPath.keys()]
+    .filter((path) => path.startsWith(prefix))
+    .map((path) => path.slice(prefix.length))
+    .sort();
+}
+
+export function listMobDescriptors(
+  catalog: AnimationCatalog,
+): MobCatalogDescriptor[] {
   const descriptors: MobCatalogDescriptor[] = [];
 
   for (const path of catalog.tracksByPath.keys()) {
@@ -297,24 +326,25 @@ export function listMobDescriptors(catalog: AnimationCatalog): MobCatalogDescrip
 }
 
 /** Returns prop groups under a prop family (e.g. "chest", "water", "barrels"). */
-export function getPropGroups(catalog: AnimationCatalog, family: string): string[] {
-  const prefix = `props/${family}/`;
-  return [...catalog.tracksByPath.keys()]
-    .filter((p) => p.startsWith(prefix))
-    .map((p) => p.slice(prefix.length))
-    .sort();
+export function getPropGroups(
+  catalog: AnimationCatalog,
+  family: string,
+): string[] {
+  return listCatalogPathSuffixes(catalog, `props/${family}/`);
 }
 
 /** Returns tileset groups under a tileset family (e.g. "environment", "structure"). */
-export function getTilesetGroups(catalog: AnimationCatalog, family: TilesetFamily): string[] {
-  const prefix = `tilesets/${family}/`;
-  return [...catalog.tracksByPath.keys()]
-    .filter((p) => p.startsWith(prefix))
-    .map((p) => p.slice(prefix.length))
-    .sort();
+export function getTilesetGroups(
+  catalog: AnimationCatalog,
+  family: TilesetFamily,
+): string[] {
+  return listCatalogPathSuffixes(catalog, `tilesets/${family}/`);
 }
 
 /** Returns tracks for the given path, or [] if not found. */
-export function getTracksForPath(catalog: AnimationCatalog, path: string): AnimationTrack[] {
+export function getTracksForPath(
+  catalog: AnimationCatalog,
+  path: string,
+): AnimationTrack[] {
   return catalog.tracksByPath.get(path) ?? [];
 }

--- a/apps/frontend/src/game/scenes/PreviewScene.ts
+++ b/apps/frontend/src/game/scenes/PreviewScene.ts
@@ -78,6 +78,34 @@ export class PreviewScene extends Phaser.Scene {
     this.game.events.emit(PREVIEW_READY_EVENT);
   }
 
+  private getPreviewCenter(): { x: number; y: number } {
+    return {
+      x: Math.round(this.scale.width / 2),
+      y: Math.round(this.scale.height / 2),
+    };
+  }
+
+  private ensurePreviewSprite(
+    textureKey: string,
+    textureFrame: string | number,
+    syncTexture: boolean,
+  ): Phaser.GameObjects.Sprite {
+    const { x, y } = this.getPreviewCenter();
+
+    if (!this.sprite) {
+      this.sprite = this.add.sprite(x, y, textureKey, textureFrame);
+      this.sprite.setScale(PREVIEW_SCALE);
+      return this.sprite;
+    }
+
+    if (syncTexture) {
+      this.sprite.setTexture(textureKey, textureFrame);
+    }
+
+    this.sprite.setPosition(x, y);
+    return this.sprite;
+  }
+
   private onPlay(payload: PreviewPlayPayload): void {
     const { key, flipX, equipKey, equipFlipX, frameIndex } = payload;
 
@@ -85,35 +113,42 @@ export class PreviewScene extends Phaser.Scene {
     const firstFrame = animation?.frames[0];
     if (!animation || !firstFrame) return;
 
-    const cx = Math.round(this.scale.width / 2);
-    const cy = Math.round(this.scale.height / 2);
-
-    if (!this.sprite) {
-      this.sprite = this.add.sprite(cx, cy, firstFrame.textureKey, firstFrame.textureFrame);
-      this.sprite.setScale(PREVIEW_SCALE);
-    }
-
     const resolvedFrameIndex =
       typeof frameIndex === "number" && Number.isFinite(frameIndex)
-        ? Phaser.Math.Clamp(Math.floor(frameIndex), 0, animation.frames.length - 1)
+        ? Phaser.Math.Clamp(
+            Math.floor(frameIndex),
+            0,
+            animation.frames.length - 1,
+          )
         : null;
     const selectedAnimationFrame =
-      resolvedFrameIndex === null ? firstFrame : animation.frames[resolvedFrameIndex];
+      resolvedFrameIndex === null
+        ? firstFrame
+        : animation.frames[resolvedFrameIndex];
     if (!selectedAnimationFrame) return;
 
-    this.sprite.setFlip(flipX, false);
-    this.sprite.setRotation(0);
+    const previewSprite = this.ensurePreviewSprite(
+      selectedAnimationFrame.textureKey,
+      selectedAnimationFrame.textureFrame,
+      resolvedFrameIndex !== null,
+    );
+    const { x: centerX, y: centerY } = this.getPreviewCenter();
+
+    previewSprite.setFlip(flipX, false);
+    previewSprite.setRotation(0);
     if (resolvedFrameIndex === null) {
-      this.sprite.play(key, false);
+      previewSprite.play(key, false);
     } else {
-      this.sprite.setTexture(selectedAnimationFrame.textureKey, selectedAnimationFrame.textureFrame);
-      this.sprite.setPosition(cx, cy);
-      this.sprite.stop();
+      previewSprite.stop();
     }
 
-    if (resolvedFrameIndex === null && equipKey && this.anims.exists(equipKey)) {
+    if (
+      resolvedFrameIndex === null &&
+      equipKey &&
+      this.anims.exists(equipKey)
+    ) {
       if (!this.equipSprite) {
-        this.equipSprite = this.add.sprite(cx, cy, EQUIPMENT_ATLAS);
+        this.equipSprite = this.add.sprite(centerX, centerY, EQUIPMENT_ATLAS);
         this.equipSprite.setScale(PREVIEW_SCALE);
       }
       this.equipSprite.setFlipX(equipFlipX);
@@ -143,28 +178,28 @@ export class PreviewScene extends Phaser.Scene {
   }
 
   private onShowTile(payload: PreviewShowTilePayload): void {
-    const { textureKey, frame, caseId, materialId, cellX, cellY, rotate90, flipX, flipY } = payload;
+    const {
+      textureKey,
+      frame,
+      caseId,
+      materialId,
+      cellX,
+      cellY,
+      rotate90,
+      flipX,
+      flipY,
+    } = payload;
     if (!this.textures.exists(textureKey)) return;
 
     const texture = this.textures.get(textureKey);
     const resolvedFrame = texture.get(frame);
     if (!resolvedFrame) return;
 
-    const cx = Math.round(this.scale.width / 2);
-    const cy = Math.round(this.scale.height / 2);
-
-    if (!this.sprite) {
-      this.sprite = this.add.sprite(cx, cy, textureKey, frame);
-      this.sprite.setScale(PREVIEW_SCALE);
-    } else {
-      this.sprite.setTexture(textureKey, frame);
-      this.sprite.setPosition(cx, cy);
-    }
-
-    this.sprite.setFlip(flipX, flipY);
-    this.sprite.setRotation(rotate90 * (Math.PI / 2));
-    this.sprite.setScale(PREVIEW_SCALE);
-    this.sprite.stop();
+    const previewSprite = this.ensurePreviewSprite(textureKey, frame, true);
+    previewSprite.setFlip(flipX, flipY);
+    previewSprite.setRotation(rotate90 * (Math.PI / 2));
+    previewSprite.setScale(PREVIEW_SCALE);
+    previewSprite.stop();
 
     if (this.equipSprite) {
       this.equipSprite.setVisible(false);

--- a/apps/frontend/src/game/scenes/world/__tests__/worldScene.terrainPainting.test.ts
+++ b/apps/frontend/src/game/scenes/world/__tests__/worldScene.terrainPainting.test.ts
@@ -38,6 +38,8 @@ type WorldPoint = {
   y: number;
 };
 
+const OCCUPIED_ENTITY_POSITIONS: WorldPoint[] = [{ x: 96, y: 96 }];
+
 function createSceneHarness(input?: {
   entityPositions?: WorldPoint[];
   worldPoint?: WorldPoint;
@@ -91,7 +93,9 @@ function createSceneHarness(input?: {
     previewPaintAtWorld,
     queueDrop,
   };
-  scene.entities = (input?.entityPositions ?? []).map((position) => ({ position }));
+  scene.entities = (input?.entityPositions ?? []).map((position) => ({
+    position,
+  }));
   scene.activeTerrainTool = {
     materialId: "water",
     brushId: "water",
@@ -108,6 +112,24 @@ function createSceneHarness(input?: {
   };
 }
 
+function createOccupiedSceneHarness() {
+  return createSceneHarness({
+    entityPositions: OCCUPIED_ENTITY_POSITIONS,
+  });
+}
+
+function paintTerrainAtPointer(scene: Record<string, unknown>): void {
+  (scene.paintTerrainAtScreen as (screenX: number, screenY: number) => void)(
+    12,
+    34,
+  );
+}
+
+function beginBrushPaint(scene: Record<string, unknown>): void {
+  (scene.terrainPaintSession as TerrainPaintSession).begin();
+  paintTerrainAtPointer(scene);
+}
+
 describe("WorldScene terrain painting", () => {
   test("positions the selection badge above the anchored sprite top edge", () => {
     const scene = new WorldScene() as unknown as Record<string, unknown>;
@@ -117,10 +139,12 @@ describe("WorldScene terrain painting", () => {
 
     scene.selectionBadge = selectionBadge;
 
-    (scene.syncSelectionBadgePosition as (entity: {
-      position: { x: number; y: number };
-      sprite: { displayHeight: number };
-    }) => void)({
+    (
+      scene.syncSelectionBadgePosition as (entity: {
+        position: { x: number; y: number };
+        sprite: { displayHeight: number };
+      }) => void
+    )({
       position: { x: 128, y: 192 },
       sprite: { displayHeight: 96 },
     });
@@ -147,33 +171,23 @@ describe("WorldScene terrain painting", () => {
   });
 
   test("does not queue brush paint when the target cell is occupied", () => {
-    const { scene, queueDrop } = createSceneHarness({
-      entityPositions: [{ x: 96, y: 96 }],
-    });
-
-    (scene.terrainPaintSession as TerrainPaintSession).begin();
-    (scene.paintTerrainAtScreen as (screenX: number, screenY: number) => void)(12, 34);
+    const { scene, queueDrop } = createOccupiedSceneHarness();
+    beginBrushPaint(scene);
 
     expect(queueDrop).not.toHaveBeenCalled();
   });
 
   test("occupied cells are not marked as painted for the rest of the stroke", () => {
-    const { scene, queueDrop } = createSceneHarness({
-      entityPositions: [{ x: 96, y: 96 }],
-    });
-
-    (scene.terrainPaintSession as TerrainPaintSession).begin();
-    (scene.paintTerrainAtScreen as (screenX: number, screenY: number) => void)(12, 34);
+    const { scene, queueDrop } = createOccupiedSceneHarness();
+    beginBrushPaint(scene);
     scene.entities = [];
-    (scene.paintTerrainAtScreen as (screenX: number, screenY: number) => void)(12, 34);
+    paintTerrainAtPointer(scene);
 
     expect(queueDrop).toHaveBeenCalledOnce();
   });
 
   test("drop-based terrain edits also skip occupied cells", () => {
-    const { scene, queueDrop } = createSceneHarness({
-      entityPositions: [{ x: 96, y: 96 }],
-    });
+    const { scene, queueDrop } = createOccupiedSceneHarness();
 
     (
       scene.onPlaceTerrainDrop as (payload: {
@@ -199,7 +213,12 @@ describe("WorldScene terrain painting", () => {
       worldPoint: { x: 100, y: 110 },
     });
 
-    (scene.syncTerrainBrushPreviewAtScreen as (screenX: number, screenY: number) => void)(12, 34);
+    (
+      scene.syncTerrainBrushPreviewAtScreen as (
+        screenX: number,
+        screenY: number,
+      ) => void
+    )(12, 34);
 
     expect(worldToCell).toHaveBeenCalledWith(100, 110);
     expect(terrainBrushPreview.setPosition).toHaveBeenCalledWith(64, 64);
@@ -224,9 +243,15 @@ describe("WorldScene terrain painting", () => {
     });
     const syncTerrainBrushRenderPreviewTiles = vi.fn();
 
-    scene.syncTerrainBrushRenderPreviewTiles = syncTerrainBrushRenderPreviewTiles;
+    scene.syncTerrainBrushRenderPreviewTiles =
+      syncTerrainBrushRenderPreviewTiles;
 
-    (scene.syncTerrainBrushPreviewAtScreen as (screenX: number, screenY: number) => void)(12, 34);
+    (
+      scene.syncTerrainBrushPreviewAtScreen as (
+        screenX: number,
+        screenY: number,
+      ) => void
+    )(12, 34);
 
     expect(previewPaintAtWorld).toHaveBeenCalledWith(
       {
@@ -239,7 +264,9 @@ describe("WorldScene terrain painting", () => {
       96,
       96,
     );
-    expect(syncTerrainBrushRenderPreviewTiles).toHaveBeenCalledWith(previewTiles);
+    expect(syncTerrainBrushRenderPreviewTiles).toHaveBeenCalledWith(
+      previewTiles,
+    );
   });
 
   test("positions resolved render-tile preview images on the shifted render grid", () => {
@@ -261,15 +288,19 @@ describe("WorldScene terrain painting", () => {
     };
     scene.terrainBrushRenderPreviewImages = [];
 
-    (scene.syncTerrainBrushRenderPreviewTiles as (tiles: Array<{
-      cellX: number;
-      cellY: number;
-      caseId: number;
-      frame: string;
-      rotate90: 0 | 1 | 2 | 3;
-      flipX: boolean;
-      flipY: boolean;
-    }>) => void)([
+    (
+      scene.syncTerrainBrushRenderPreviewTiles as (
+        tiles: Array<{
+          cellX: number;
+          cellY: number;
+          caseId: number;
+          frame: string;
+          rotate90: 0 | 1 | 2 | 3;
+          flipX: boolean;
+          flipY: boolean;
+        }>,
+      ) => void
+    )([
       {
         cellX: 1,
         cellY: 1,
@@ -289,7 +320,12 @@ describe("WorldScene terrain painting", () => {
       worldToCellResult: null,
     });
 
-    (scene.syncTerrainBrushPreviewAtScreen as (screenX: number, screenY: number) => void)(12, 34);
+    (
+      scene.syncTerrainBrushPreviewAtScreen as (
+        screenX: number,
+        screenY: number,
+      ) => void
+    )(12, 34);
 
     expect(terrainBrushPreview.setVisible).toHaveBeenCalledWith(false);
     expect(terrainBrushPreview.setPosition).not.toHaveBeenCalled();
@@ -300,10 +336,17 @@ describe("WorldScene terrain painting", () => {
     const syncTerrainBrushPreviewFromPointer = vi.fn();
     const paintTerrainAtScreen = vi.fn();
 
-    scene.syncTerrainBrushPreviewFromPointer = syncTerrainBrushPreviewFromPointer;
+    scene.syncTerrainBrushPreviewFromPointer =
+      syncTerrainBrushPreviewFromPointer;
     scene.paintTerrainAtScreen = paintTerrainAtScreen;
 
-    (scene.onPointerMove as (pointer: { withinGame: boolean; x: number; y: number }) => void)({
+    (
+      scene.onPointerMove as (pointer: {
+        withinGame: boolean;
+        x: number;
+        y: number;
+      }) => void
+    )({
       withinGame: true,
       x: 12,
       y: 34,
@@ -353,10 +396,12 @@ describe("WorldScene terrain painting", () => {
     scene.syncTerrainBrushPreviewAtScreen = syncTerrainBrushPreviewAtScreen;
 
     (
-      scene.onSelectTerrainTool as (tool: {
-        materialId: string;
-        brushId: string;
-      } | null) => void
+      scene.onSelectTerrainTool as (
+        tool: {
+          materialId: string;
+          brushId: string;
+        } | null,
+      ) => void
     )({
       materialId: "water",
       brushId: "water",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "jscpd": "4.0.8",
         "knip": "5.86.0"
       }
     },
@@ -333,6 +334,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@emnapi/core": {
@@ -808,6 +820,71 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jscpd/badge-reporter": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.0.4.tgz",
+      "integrity": "sha512-I9b4MmLXPM2vo0SxSUWnNGKcA4PjQlD3GzXvFK60z43cN/EIdLbOq3FVwCL+dg2obUqGXKIzAm7EsDFTg0D+mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "badgen": "^3.2.3",
+        "colors": "^1.4.0",
+        "fs-extra": "^11.2.0"
+      }
+    },
+    "node_modules/@jscpd/core": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.0.4.tgz",
+      "integrity": "sha512-QGMT3iXEX1fI6lgjPH+x8eyJwhwr2KkpSF5uBpjC0Z5Xloj0yFTFLtwJT+RhxP/Ob4WYrtx2jvpKB269oIwgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/@jscpd/finder": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.0.4.tgz",
+      "integrity": "sha512-qVUWY7Nzuvfd5OIk+n7/5CM98LmFroLqblRXAI2gDABwZrc7qS+WH2SNr0qoUq0f4OqwM+piiwKvwL/VDNn/Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jscpd/core": "4.0.4",
+        "@jscpd/tokenizer": "4.0.4",
+        "blamer": "^1.0.6",
+        "bytes": "^3.1.2",
+        "cli-table3": "^0.6.5",
+        "colors": "^1.4.0",
+        "fast-glob": "^3.3.2",
+        "fs-extra": "^11.2.0",
+        "markdown-table": "^2.0.0",
+        "pug": "^3.0.3"
+      }
+    },
+    "node_modules/@jscpd/html-reporter": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.0.4.tgz",
+      "integrity": "sha512-YiepyeYkeH74Kx59PJRdUdonznct0wHPFkf6FLQN+mCBoy6leAWCcOfHtcexnp+UsBFDlItG5nRdKrDSxSH+Kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "1.4.0",
+        "fs-extra": "^11.2.0",
+        "pug": "^3.0.3"
+      }
+    },
+    "node_modules/@jscpd/tokenizer": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.0.4.tgz",
+      "integrity": "sha512-xxYYY/qaLah/FlwogEbGIxx9CjDO+G9E6qawcy26WwrflzJb6wsnhjwdneN6Wb0RNCDsqvzY+bzG453jsin4UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jscpd/core": "4.0.4",
+        "reprism": "^0.0.11",
+        "spark-md5": "^3.0.2"
       }
     },
     "node_modules/@jsdevtools/ono": {
@@ -1669,6 +1746,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1805,6 +1889,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -1822,12 +1919,36 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assert-never": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
+      "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1838,6 +1959,26 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/babel-walk": {
+      "version": "3.0.0-canary-5",
+      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.9.6"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/badgen": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/badgen/-/badgen-3.2.3.tgz",
+      "integrity": "sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
@@ -1850,6 +1991,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/blamer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/blamer/-/blamer-1.0.7.tgz",
+      "integrity": "sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^4.0.0",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=8.9"
       }
     },
     "node_modules/braces": {
@@ -1899,6 +2054,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1907,6 +2072,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1947,6 +2143,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/character-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+      "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-regex": "^1.0.3"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1957,12 +2163,74 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constantinople": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
+      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.1"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1999,6 +2267,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/doctypes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
@@ -2006,12 +2296,62 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2077,6 +2417,30 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2196,6 +2560,21 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2211,6 +2590,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2219,6 +2608,71 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gitignore-to-glob": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/gitignore-to-glob/-/gitignore-to-glob-0.3.0.tgz",
+      "integrity": "sha512-mk74BdnK7lIwDHnotHddx1wsjMOFIThpLY3cPNniJ/2fA/tlLzHnFxIdR+4sLOu5KGgQJdij4kjJ2RoUNnCNMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.4 <5 || >=6.9"
       }
     },
     "node_modules/glob-parent": {
@@ -2234,6 +2688,105 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-expression": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "object-assign": "^4.1.1"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2242,6 +2795,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2267,6 +2830,52 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2276,6 +2885,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2294,6 +2910,40 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jscpd": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.0.8.tgz",
+      "integrity": "sha512-d2VNT/2Hv4dxT2/59He8Lyda4DYOxPRyRG9zBaOpTZAqJCVf2xLrBlZkT8Va6Lo9u3X2qz8Bpq4HrDi4JsrQhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jscpd/badge-reporter": "4.0.4",
+        "@jscpd/core": "4.0.4",
+        "@jscpd/finder": "4.0.4",
+        "@jscpd/html-reporter": "4.0.4",
+        "@jscpd/tokenizer": "4.0.4",
+        "colors": "^1.4.0",
+        "commander": "^5.0.0",
+        "fs-extra": "^11.2.0",
+        "gitignore-to-glob": "^0.3.0",
+        "jscpd-sarif-reporter": "4.0.6"
+      },
+      "bin": {
+        "jscpd": "bin/jscpd"
+      }
+    },
+    "node_modules/jscpd-sarif-reporter": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.0.6.tgz",
+      "integrity": "sha512-b9Sm3IPZ3+m8Lwa4gZa+4/LhDhlc/ZLEsLXKSOy1DANQ6kx0ueqZT+fUHWEdQ6m0o3+RIVIa7DmvLSojQD05ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "^1.4.0",
+        "fs-extra": "^11.2.0",
+        "node-sarif-builder": "^3.4.0"
       }
     },
     "node_modules/jsesc": {
@@ -2351,6 +3001,30 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jstransformer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+      "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
       }
     },
     "node_modules/knip": {
@@ -2442,6 +3116,37 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2477,6 +3182,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimist": {
@@ -2522,6 +3237,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-sarif-builder": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sarif": "^2.1.7",
+        "fs-extra": "^11.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/oxc-resolver": {
       "version": "11.19.1",
       "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
@@ -2553,6 +3331,23 @@
         "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
         "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
       }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2645,6 +3440,163 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/pug": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
+      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pug-code-gen": "^3.0.3",
+        "pug-filters": "^4.0.0",
+        "pug-lexer": "^5.0.1",
+        "pug-linker": "^4.0.0",
+        "pug-load": "^3.0.0",
+        "pug-parser": "^6.0.0",
+        "pug-runtime": "^3.0.1",
+        "pug-strip-comments": "^2.0.0"
+      }
+    },
+    "node_modules/pug-attrs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "constantinople": "^4.0.1",
+        "js-stringify": "^1.0.2",
+        "pug-runtime": "^3.0.0"
+      }
+    },
+    "node_modules/pug-code-gen": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "constantinople": "^4.0.1",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.2",
+        "pug-attrs": "^3.0.0",
+        "pug-error": "^2.1.0",
+        "pug-runtime": "^3.0.1",
+        "void-elements": "^3.1.0",
+        "with": "^7.0.0"
+      }
+    },
+    "node_modules/pug-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pug-filters": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
+      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "constantinople": "^4.0.1",
+        "jstransformer": "1.0.0",
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0",
+        "resolve": "^1.15.1"
+      }
+    },
+    "node_modules/pug-lexer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-parser": "^2.2.0",
+        "is-expression": "^4.0.0",
+        "pug-error": "^2.0.0"
+      }
+    },
+    "node_modules/pug-linker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
+      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0"
+      }
+    },
+    "node_modules/pug-load": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
+      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "pug-walk": "^2.0.0"
+      }
+    },
+    "node_modules/pug-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pug-error": "^2.0.0",
+        "token-stream": "1.0.0"
+      }
+    },
+    "node_modules/pug-runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pug-strip-comments": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pug-error": "^2.0.0"
+      }
+    },
+    "node_modules/pug-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
+      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2701,6 +3653,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/reprism": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/reprism/-/reprism-0.0.11.tgz",
+      "integrity": "sha512-VsxDR5QxZo08M/3nRypNlScw5r3rKeSOPdU/QhDmu3Ai3BJxHn/qgfXGWQp/tAxUtzwYNo9W6997JZR0tPLZsA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2709,6 +3678,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/reusify": {
@@ -2810,10 +3800,40 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2840,6 +3860,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2853,6 +3880,44 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
@@ -2886,6 +3951,19 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2961,6 +4039,13 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+      "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2999,6 +4084,16 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3187,6 +4282,16 @@
         }
       }
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -3195,6 +4300,22 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/why-is-node-running": {
@@ -3213,6 +4334,29 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/with": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
+        "assert-never": "^1.2.1",
+        "babel-walk": "3.0.0-canary-5"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "assets:donarg:all": "npm run -w @towncord/donarg-office-assets export:all",
     "build": "echo \"Define workspace build scripts\"",
     "dev": "echo \"Define workspace dev scripts\"",
+    "jscpd": "jscpd --config .jscpd.json",
     "knip": "knip --include files,dependencies,exports,types --include-entry-exports --reporter compact --treat-config-hints-as-errors",
     "test": "echo \"Define workspace tests\"",
     "test:automation": "node --test .github/scripts/__tests__/*.test.mjs"
   },
   "devDependencies": {
+    "jscpd": "4.0.8",
     "knip": "5.86.0"
   }
 }


### PR DESCRIPTION
## Summary
- add jscpd as a root dev dependency with a committed .jscpd.json and CI coverage
- refactor duplicated frontend/test/script code until the jscpd report is clean at 0 clones
- add an automation check that PR CI runs jscpd

## Verification
- npm run jscpd
- npm run test:automation
- npm run typecheck:frontend
- npm -w @towncord/frontend test
- npm run build:frontend