### PR TITLE
fix: always update CI report comment on success

### DIFF
--- a/.github/scripts/post_ci_report.py
+++ b/.github/scripts/post_ci_report.py
@@ -323,10 +323,6 @@ def main() -> None:
     pr_number = os.environ["PR_NUMBER"]
     repo = os.environ["REPO"]
 
-    if not any(v == "failure" for v in outcomes.values()):
-        print("All checks passed — no comment needed")
-        return
-
     comment = compose_comment(outcomes, run_url)
     post_comment(repo, pr_number, comment)
 


### PR DESCRIPTION
## Summary
- Remove the early-return in `post_ci_report.py` that skipped posting when all CI checks passed
- The comment is now always created or updated, so a stale failure comment is replaced with a ✅ success report when a subsequent push fixes all issues

## Test plan
- [ ] Push a failing commit to a PR — failure comment appears
- [ ] Push a fix — comment updates to show all ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)