### PR TITLE
ci: make knip/jscpd non-blocking, reset jscpd threshold to 0%

### DIFF
--- a/.github/scripts/post_ci_report.py
+++ b/.github/scripts/post_ci_report.py
@@ -12,6 +12,8 @@ MARKER = "<!-- ci-report -->"
 
 STEP_ORDER = ["audit", "knip", "jscpd", "typecheck", "tests", "build"]
 
+WARN_STEPS = {"knip", "jscpd"}
+
 STEP_LABELS = {
     "audit": "npm audit (high/critical)",
     "knip": "unused deps/exports/files",
@@ -74,7 +76,7 @@ def read_log(step: str) -> str:
 
 
 def outcome_emoji(outcome: str) -> str:
-    return {"success": "✅", "failure": "❌", "skipped": "⏭️"}.get(outcome, "⏭️")
+    return {"success": "✅", "failure": "❌", "warning": "⚠️", "skipped": "⏭️"}.get(outcome, "⏭️")
 
 
 def skip_npm_boilerplate(lines: list[str]) -> list[str]:
@@ -248,7 +250,7 @@ def compose_comment(outcomes: dict[str, str], run_url: str) -> str:
     parts.append("")
 
     for step in STEP_ORDER:
-        if outcomes.get(step) != "failure":
+        if outcomes.get(step) not in ("failure", "warning"):
             continue
         log = read_log(step)
         suffix, detail = EXTRACTORS[step](log)
@@ -315,9 +317,13 @@ def post_comment(repo: str, pr_number: str, body: str) -> None:
 
 
 def main() -> None:
-    outcomes = {
+    raw_outcomes = {
         step: os.environ.get(f"{step.upper()}_OUTCOME", "skipped")
         for step in STEP_ORDER
+    }
+    outcomes = {
+        step: ("warning" if outcome == "failure" and step in WARN_STEPS else outcome)
+        for step, outcome in raw_outcomes.items()
     }
     run_url = os.environ["RUN_URL"]
     pr_number = os.environ["PR_NUMBER"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,6 @@ jobs:
         run: |
           failed=()
           [[ "${{ steps.audit.outcome }}"     != "success" ]] && failed+=("audit")
-          [[ "${{ steps.knip.outcome }}"      != "success" ]] && failed+=("knip")
-          [[ "${{ steps.jscpd.outcome }}"     != "success" ]] && failed+=("jscpd")
           [[ "${{ steps.typecheck.outcome }}" != "success" ]] && failed+=("typecheck")
           [[ "${{ steps.tests.outcome }}"     != "success" ]] && failed+=("tests")
           [[ "${{ steps.build.outcome }}"     != "success" ]] && failed+=("build")

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,5 +1,5 @@
 {
-  "threshold": 5,
+  "threshold": 0,
   "gitignore": true,
   "reporters": ["console"],
   "path": [


### PR DESCRIPTION
## Summary

- **Reset jscpd threshold** from 5% back to 0% (reverts the relaxation from #78)
- **knip and jscpd are now informational-only** — their results no longer gate the pipeline. `audit`, `typecheck`, `tests`, and `build` continue to block on failure.
- **CI report comment** now shows `⚠️` (instead of `❌`) for knip/jscpd issues, with detail blocks still expanding when findings exist. The overall `✅`/`❌` badge excludes them.

## Test plan

- [ ] Verify all 17 automation tests pass (they do locally)
- [ ] Trigger CI on this PR and confirm: knip/jscpd findings show `⚠️` in the comment, pipeline still passes
- [ ] Confirm that audit/typecheck/tests/build failures still produce `❌` and fail the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)