### PR TITLE
chore: attach submodules to local branch on bootstrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5269,18 +5269,15 @@
     },
     "packages/bloomseed-assets": {
       "name": "@towncord/bloomseed-assets",
-      "version": "0.1.0",
-      "extraneous": true
+      "version": "0.1.0"
     },
     "packages/debug-assets": {
       "name": "@towncord/debug-assets",
-      "version": "0.1.0",
-      "extraneous": true
+      "version": "0.1.0"
     },
     "packages/donarg-office-assets": {
       "name": "@towncord/donarg-office-assets",
-      "version": "0.1.0",
-      "extraneous": true
+      "version": "0.1.0"
     },
     "packages/public-animation-contracts": {
       "name": "@towncord/public-animation-contracts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "bootstrap": "git submodule update --init --recursive && npm install",
+    "bootstrap": "git submodule update --init --recursive && npm install && sh scripts/attach-submodules.sh",
     "postinstall": "npm run -w @towncord/public-animation-contracts generate",
     "dev:frontend": "sh -c 'npm run assets:public && npm run -w @towncord/frontend dev -- \"$@\"' --",
     "build:frontend": "npm run assets:public && npm run -w @towncord/frontend build",

--- a/scripts/attach-submodules.sh
+++ b/scripts/attach-submodules.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Attaches each submodule to a local branch named after the parent repo's current branch,
+# pointing at the pinned commit recorded in the parent index.
+set -e
+
+PARENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$PARENT_BRANCH" = "HEAD" ]; then
+  echo "attach-submodules: parent repo is in detached HEAD — skipping branch attachment"
+  exit 0
+fi
+
+git submodule foreach --quiet '
+  branch="'"$PARENT_BRANCH"'"
+  git checkout -B "$branch"
+  echo "  $name: attached to branch $branch at $(git rev-parse --short HEAD)"
+'


### PR DESCRIPTION
## Summary

- Adds `scripts/attach-submodules.sh` which creates (or resets) a local branch in each submodule named after the parent repo's current branch, pointing at the pinned commit
- Updates `npm run bootstrap` to call the script after submodule init
- `package-lock.json` updated to remove spurious `extraneous` flags on submodule packages

## Why

After `git submodule update --init --recursive`, submodules land in detached HEAD. This makes it impossible to commit changes inside a submodule without first manually attaching to a branch. By naming the branch after the parent repo's current branch (e.g. `session/tow-17`), each worktree gets its own isolated submodule branch at the correct pinned commit — reproducible but workable.

## Behaviour

- Idempotent: re-running `npm run bootstrap` resets the branch in place via `git checkout -B`
- Safe: if the parent repo is itself in detached HEAD, the script exits early with a warning instead of creating a branch named `HEAD`

## Test plan

- [ ] Run `npm run bootstrap` on a fresh clone and verify all submodules show a branch name matching the current branch (`git submodule foreach 'git branch --show-current'`)
- [ ] Re-run `npm run bootstrap` and confirm it completes without errors (idempotency)
- [ ] Verify submodule commits match the previously pinned commits after attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)